### PR TITLE
Update sha256 checksum

### DIFF
--- a/wsl-ubuntu-2204/tools/chocolateyInstall.ps1
+++ b/wsl-ubuntu-2204/tools/chocolateyInstall.ps1
@@ -10,7 +10,7 @@ if ([bool]$packageParameters.AutomaticInstall -eq $true) {
 $packageArgs = @{
     packageName    = 'wsl-ubuntu-2204'
     softwareName   = 'Ubuntu 22.04 LTS for WSL'
-    checksum       = 'c5028547edfe72be8f7d44ef52cee5aacaf9b1ae1ed4f7e39b94dae3cf286bc2'
+    checksum       = '6ad6d88763451a50f98f2469ce80464d666204c08d07f8f6a89e0d5ca05b097a'
     checksumType   = 'sha256'
     url            = 'https://aka.ms/wslubuntu2204'
     fileFullPath   = "$env:TEMP\ubuntu2204.appx"


### PR DESCRIPTION
The package is currently broken because the checksum of the upstream downloaded package has changed. According to the package comments, it's been this way for since at least November of 2022. This PR updates it to the current true checksum.

You can verify the checksum yourself with the following steps:

```sh
wget https://aka.ms/wslubuntu2204
sha256sum wslubuntu2204
```

(Should output: `6ad6d88763451a50f98f2469ce80464d666204c08d07f8f6a89e0d5ca05b097a  wslubuntu2204`)